### PR TITLE
Change Target Framework to .Net Framework 4.8

### DIFF
--- a/streamdeck-advancedlauncher/AdvancedLauncher.csproj
+++ b/streamdeck-advancedlauncher/AdvancedLauncher.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>AdvancedLauncher</RootNamespace>
     <AssemblyName>com.barraider.advancedlauncher</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/streamdeck-advancedlauncher/App.config
+++ b/streamdeck-advancedlauncher/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/streamdeck-advancedlauncher/packages.config
+++ b/streamdeck-advancedlauncher/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.9.1" targetFramework="net472" />
-  <package id="Gameloop.Vdf" version="0.6.2" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
-  <package id="NLog" version="5.1.4" targetFramework="net481" />
-  <package id="StreamDeck-Tools" version="6.1.1" targetFramework="net472" />
-  <package id="System.Drawing.Common" version="7.0.0" targetFramework="net472" />
+  <package id="CommandLineParser" version="2.9.1" targetFramework="net48" />
+  <package id="Gameloop.Vdf" version="0.6.2" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="NLog" version="5.2.2" targetFramework="net48" />
+  <package id="StreamDeck-Tools" version="6.1.1" targetFramework="net48" />
+  <package id="System.Drawing.Common" version="7.0.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
.Net Framework 4.8 is recommended over 4.8.1 by Microsoft ([link](https://learn.microsoft.com/en-us/answers/questions/1183148/why-does-microsoft-still-recommend-the-net-framewo)). It's supported by all still mainentded os versions.

I've build solution and tested it to make sure everything works and it didn't break anything.